### PR TITLE
Fix error,  "(0 , _nuxt.defineNuxtConfig) is not a function" on yarn dev

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,4 @@
-import { defineNuxtConfig } from 'nuxt'
+import { defineNuxtConfig } from 'nuxt/config';
 import Components from 'unplugin-vue-components/vite';
 import { NaiveUiResolver } from 'unplugin-vue-components/resolvers';
 // https://v3.nuxtjs.org/docs/directory-structure/nuxt.config


### PR DESCRIPTION
A wrong import in the nuxt.config.ts throws an error on yarn dev. This PR resolves this issue.